### PR TITLE
Objetos para armar toolbox

### DIFF
--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -2,6 +2,171 @@ import Ember from 'ember';
 
 var Blockly = window.Blockly;
 
+/*
+   Modelo que permite definir el lenguaje
+   de una actividad
+*/
+
+var BloqueCategoria = Ember.Object.extend({
+   init: function() {
+      this.set('bloques', []);
+   },
+      
+   agregar_simple: function(blockType) {
+     this.get('bloques').pushObject(Bloque.create({
+       tipo: blockType
+     }));
+   },
+
+   agregar_con_params: function(blockType, params) {
+    var nuevo_bloque = Bloque.create({
+       tipo: blockType
+    });
+
+    nuevo_bloque.agregar(params);
+    
+    this.get('bloques').pushObject(nuevo_bloque);
+   },
+   
+   borrar: function(blockType) {
+     this.get('bloques').forEach(function (item) {
+       if(item.get('tipo') === blockType) {
+           this.get('bloques').removeObject(item);
+       }
+     });
+   },
+
+   build: function() {
+     var str_category = '';
+     
+     str_category += '<category name="x">\n'.replace("x", this.get('nombre'));
+     
+     this.get('bloques').forEach(function(item) {
+         str_category += item.build();
+     });
+     
+     str_category += '</category>\n';
+     
+     return str_category;
+   }
+});
+
+var Bloque = Ember.Object.extend({
+   init: function() {
+      this.set('parametros', []);
+   },
+   
+   agregar: function(params) {
+      var yo = this;
+      params.forEach( function(item) {
+         yo.get('parametros').pushObject(item);
+      });
+   },
+   
+   build: function() {
+     var str_block = '';
+     str_block += '<block type="TIPO">'.replace("TIPO", this.get('tipo'));
+     
+     this.get('parametros').forEach(function(item) {
+         str_block += item.build();
+     });
+     
+     str_block += '</block>';
+     return str_block;
+   }
+});
+
+var ParamCampo = Ember.Object.extend({
+   build: function() {
+     var str_block = '';
+     str_block += '<field name="NOMBRE">'.replace("NOMBRE", this.get('nombre_valor'));
+     str_block += this.get('valor');
+     str_block += '</field>';
+     return str_block;
+   }
+});
+
+var ParamValor = Ember.Object.extend({
+   build: function() {
+     var str_block = '';
+     str_block += '<value name="NOMBRE">'.replace("NOMBRE", this.get('nombre_param'));
+     
+     str_block += '<block type="TIPO">'.replace("TIPO", this.get('tipo_bloque'));
+     
+     str_block += '<field name="TIPO">'.replace("TIPO", this.get('nombre_valor'));
+     str_block += this.get('valor');
+     str_block += '</field>';
+     
+     str_block += '</block>';
+     
+     str_block += '</value>';
+     
+     return str_block;
+   }
+});
+
+var Lenguaje = Ember.Object.extend({
+   build: function() {
+     var str_toolbox = '';
+     
+     str_toolbox += '<xml>';
+     
+     this.get('categorias').forEach(function(item) {
+         str_toolbox += item.build();
+     });
+     
+     str_toolbox += '</xml>';
+     
+     return str_toolbox;
+   }
+});
+
+/*
+   Bloques que son parte de la actividad "Alien"
+*/
+
+var alien_primitivas = BloqueCategoria.create({
+   nombre: 'Alien'
+});
+
+alien_primitivas.agregar_simple('alien-ir_derecha');
+alien_primitivas.agregar_simple('alien-ir_izquierda');
+alien_primitivas.agregar_simple('alien-ir_arriba');
+alien_primitivas.agregar_simple('alien-ir_abajo');
+alien_primitivas.agregar_simple('alien-recoger');
+
+var alien_control = BloqueCategoria.create({
+   nombre: 'Control'
+});
+
+alien_control.agregar_con_params('repetir', [
+  ParamValor.create({
+    nombre_param: "count",
+    tipo_bloque: "math_number",
+    nombre_valor: "NUM",
+    valor: "10"
+  })
+]);
+
+alien_control.agregar_simple('si');
+alien_control.agregar_simple('sino');
+alien_control.agregar_simple('hasta');
+
+var alien_expresiones = BloqueCategoria.create({
+   nombre: 'Expresiones'
+});
+
+alien_expresiones.agregar_simple('math_number');
+alien_expresiones.agregar_simple('math_arithmetic');
+alien_expresiones.agregar_simple('logic_boolean');
+alien_expresiones.agregar_simple('logic_compare');
+alien_expresiones.agregar_simple('logic_operation');
+alien_expresiones.agregar_simple('logic_negate');
+
+var alien_lenguaje = Lenguaje.create({
+   categorias: [alien_primitivas, alien_control, alien_expresiones]
+});
+
 export default Ember.Component.extend({
   ejecutando: false,
   
@@ -59,57 +224,16 @@ export default Ember.Component.extend({
 
   }.on('didInsertElement'),
 
-  crear_dom_para_bloques: function (lista_de_bloques) {
-    var str_toolbox = '';
-    str_toolbox += '<xml>';
-
-    for (var x in lista_de_bloques) {
-      str_toolbox += '<category name="x">\n'.replace('x', x);
-
-      for (var i=0; i<lista_de_bloques[x].length; i++) {
-        str_toolbox += '  <block type="TIPO"></block>'.replace("TIPO", lista_de_bloques[x][i]);
-      }
-
-      str_toolbox += '</category>\n';
-    }
-
-    str_toolbox += '<category name="Subtareas" custom="PROCEDURE"></category>';
-
-    str_toolbox += '</xml>';
-    //console.log(str_toolbox);
-    return str_toolbox;
-  },
-
-  definir_bloques: function(bloques) {
-    Blockly.updateToolbox(this.crear_dom_para_bloques(bloques));
+  definir_bloques: function(leng) {
+    Blockly.updateToolbox(leng);
   },
 
   cargar_escenario: function(escenario) {
     var escenarios = {};
 
     escenarios.alien_laberinto = function() {
-      this.definir_bloques({
-        Alien: [ 'alien-ir_derecha', 'alien-ir_izquierda',
-                  'alien-ir_arriba', 'alien-ir_abajo',
-                  'alien-recoger'
-               ],
-       Control: [ 'repetir',
-                  'si',
-                  'sino',
-                  'hasta',
-                ],
-       Expresiones: [
-                  'math_number',
-                  'math_arithmetic',
-                  'logic_boolean',
-                  'logic_compare',
-                  'logic_operation',
-                  'logic_negate',
-                ],
-      });
-
+      this.definir_bloques(alien_lenguaje.build());
     }.bind(this);
-
 
     if (escenario in escenarios) {
       escenarios[escenario].call(this);
@@ -117,7 +241,5 @@ export default Ember.Component.extend({
     else {
       throw new Error("No se puede cargar el escenario {{ESCENARIO}}, al parecer no está declarado en pilas-blockly.js".replace("{{ESCENARIO}}", escenario));
     }
-
-
   }
 });

--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -115,6 +115,9 @@ var Lenguaje = Ember.Object.extend({
          str_toolbox += item.build();
      });
      
+     str_toolbox += '<category name="Variables" custom="VARIABLE"></category>'
+     str_toolbox += '<category name="Subtareas" custom="PROCEDURE"></category>'
+
      str_toolbox += '</xml>';
      
      return str_toolbox;

--- a/app/components/pilas-blockly.js
+++ b/app/components/pilas-blockly.js
@@ -115,8 +115,8 @@ var Lenguaje = Ember.Object.extend({
          str_toolbox += item.build();
      });
      
-     str_toolbox += '<category name="Variables" custom="VARIABLE"></category>'
-     str_toolbox += '<category name="Subtareas" custom="PROCEDURE"></category>'
+     str_toolbox += '<category name="Variables" custom="VARIABLE"></category>';
+     str_toolbox += '<category name="Subtareas" custom="PROCEDURE"></category>';
 
      str_toolbox += '</xml>';
      


### PR DESCRIPTION
Agregué objetos para armar el toolbox de una actividad (no permite definir los bloques de blockly, aunque se podría buscar la forma de que sí).

Deberíamos ver dónde conviene que estén definidos estos objetos. Los puse provisoriamente en el componente de pilas-blockly, pero no me convence.